### PR TITLE
AWS Terraform backend module

### DIFF
--- a/examples/tf-setup/README.md
+++ b/examples/tf-setup/README.md
@@ -1,0 +1,73 @@
+# Terraform State Setup
+
+More specifics to these steps found in `../../modules/aws-terraform-backend`
+
+- Update backend reference so we can init without a backend to avoid a chicken/egg problem. I have decided to put backend information in the `versions.tf` for logical organization, but where you decide to put your backend block is up to you.
+
+```bash
+
+#     backend "s3" {
+#       bucket         = "some-tf-backend-state"
+#       dynamodb_table = "terraform-lock"
+#       encrypt        = true
+#       key            = "states/terraform.tfstate"
+#       region         = "us-west-1"
+#     }
+```
+
+- Init without the backend reference.
+
+```bash
+## INIT
+terraform init -backend=false
+```
+
+- Plan and review.
+
+```bash
+## PLAN
+
+terraform plan -out=backend.plan -target=module.backend -var 's3_backend_bucket=some-tf-backend-state'
+```
+
+- Apply that plan.
+
+```bash
+## APPLY
+
+terraform apply backend.plan
+```
+
+- Update backend to point to newly created s3 bucket. Again, this block can be where you would like. I have it in `versions.tf`
+
+```bash
+    backend "s3" {
+      bucket         = "some-tf-backend-state"
+      dynamodb_table = "terraform-lock"
+      encrypt        = true
+      key            = "states/terraform.tfstate"
+      region         = "us-west-1"
+    }
+```
+
+- Reconfigure to move state to the new backend. You will be asked to migrate the state into this backend. If done correctly, after responding `yes` your state should now be in the s2 bucket.
+
+```bash
+## RECONFIGURE
+
+terraform init -reconfigure
+```
+
+- Validate resource against the backend statefile.
+
+```bash
+## VALIDATE RESOURCES
+
+terraform plan
+#################################
+## EXPECTED:
+#################################
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
+```

--- a/examples/tf-setup/global_variables.tf
+++ b/examples/tf-setup/global_variables.tf
@@ -1,0 +1,1 @@
+../global_variables.tf

--- a/examples/tf-setup/main.tf
+++ b/examples/tf-setup/main.tf
@@ -1,0 +1,6 @@
+## REFERENCE LOCAL MODULE
+module "backend" {
+  source = "../../modules/aws-terraform-backend"
+
+  s3_backend_bucket = var.s3_backend_bucket
+}

--- a/examples/tf-setup/terraform.tfvars
+++ b/examples/tf-setup/terraform.tfvars
@@ -1,0 +1,11 @@
+#################################
+## CENTRAL CONFIG
+## NOTE: If this gets too unwieldy, consider resource.auto.tfvars
+## https://developer.hashicorp.com/terraform/language/values/variables#variable-definitions-tfvars-files
+#################################
+
+## STACK
+stack = "tf-setup"
+
+## S3
+s3_backend_bucket = "some-tf-backend-state"

--- a/examples/tf-setup/variables.tf
+++ b/examples/tf-setup/variables.tf
@@ -1,0 +1,19 @@
+#################################
+## DynamoDB
+#################################
+
+variable "dynamodb_lock_table_name" {
+  description = "(Required) Unique within a region ; name of the table."
+  type        = string
+  default     = "terraform-lock"
+}
+
+#################################
+## S3
+#################################
+
+variable "s3_backend_bucket" {
+  description = "(Optional, Forces new resource) Name of the bucket. If omitted, Terraform will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules may be found here. The name must not be in the format [bucket_name]--[azid]--x-s3. Use the aws_s3_directory_bucket resource to manage S3 Express buckets."
+  type        = string
+  default     = ""
+}

--- a/examples/tf-setup/versions.tf
+++ b/examples/tf-setup/versions.tf
@@ -1,0 +1,26 @@
+#################################
+## TERRAFORM 
+#################################
+terraform {
+  required_version = "~> 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.50.0, <= 5.54.1" ## VERSION PIN OR NOT TO PIN, UP TO YOU
+    }
+  }
+  backend "s3" {
+    bucket         = var.s3_backend_bucket
+    dynamodb_table = var.dynamodb_lock_table_name
+    encrypt        = true
+    key            = "states/terraform.tfstate"
+    region         = var.aws_region
+  }
+}
+
+#################################
+## AWSPROVIDER
+#################################
+provider "aws" {
+  region = var.aws_region
+}


### PR DESCRIPTION
Adding `aws-terraform-backend` module and example used for an s3 remote state.