### PR TITLE
Cannot have variables in backend block, correcting syntax

### DIFF
--- a/examples/tf-setup/variables.tf
+++ b/examples/tf-setup/variables.tf
@@ -1,14 +1,4 @@
 #################################
-## DynamoDB
-#################################
-
-variable "dynamodb_lock_table_name" {
-  description = "(Required) Unique within a region ; name of the table."
-  type        = string
-  default     = "terraform-lock"
-}
-
-#################################
 ## S3
 #################################
 

--- a/examples/tf-setup/versions.tf
+++ b/examples/tf-setup/versions.tf
@@ -10,11 +10,11 @@ terraform {
     }
   }
   backend "s3" {
-    bucket         = var.s3_backend_bucket
-    dynamodb_table = var.dynamodb_lock_table_name
+    bucket         = "some-tf-backend-state"
+    dynamodb_table = "terraform-lock"
     encrypt        = true
     key            = "states/terraform.tfstate"
-    region         = var.aws_region
+    region         = "some-aws-region"
   }
 }
 


### PR DESCRIPTION
When planning in personal project, I could not state variables in the backend block. Corrected in public repo as well.